### PR TITLE
[update-price-p3] CF remove at unstake

### DIFF
--- a/contracts/UniversalV3Staker.sol
+++ b/contracts/UniversalV3Staker.sol
@@ -119,7 +119,9 @@ contract UniversalV3Staker is IUniversalV3Staker, Multicall {
         maxIncentiveStartLeadTime = _maxIncentiveStartLeadTime;
         maxIncentiveDuration = _maxIncentiveDuration;
 
-        uint24 numTicks = uint24(TickMath.MAX_TICK - TickMath.MIN_TICK + 1);
+        // tick range inclusive
+        // also add another zero-tick indicating `null` in cumulative function
+        uint24 numTicks = uint24(TickMath.MAX_TICK - TickMath.MIN_TICK + 1 + 1);
         uint8 nbits = BitMath.mostSignificantBit(uint256(numTicks)) + 1;
         _cfNbits = uint256(nbits);
     }

--- a/contracts/UniversalV3Staker.sol
+++ b/contracts/UniversalV3Staker.sol
@@ -161,7 +161,7 @@ contract UniversalV3Staker is IUniversalV3Staker, Multicall {
             int24 minTick = (TickMath.MIN_TICK / tickSpacing) * tickSpacing;
             int24 maxTick = (TickMath.MAX_TICK / tickSpacing) * tickSpacing;
             uint24 numTicks = uint24((maxTick - minTick) / tickSpacing) + 1;
-            uint8 nbits = BitMath.mostSignificantBit(uint256(numTicks));
+            uint8 nbits = BitMath.mostSignificantBit(uint256(numTicks)) + 1;
             _cfNbits[address(key.pool)] = uint256(nbits);
         }
     }

--- a/test/unit/__snapshots__/Deposits.spec.ts.snap
+++ b/test/unit/__snapshots__/Deposits.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`unit/Deposits #onERC721Received on successful transfer with staking data has gas cost 1`] = `217722`;
+exports[`unit/Deposits #onERC721Received on successful transfer with staking data has gas cost 1`] = `217710`;
 
 exports[`unit/Deposits #transferDeposit has gas cost 1`] = `29200`;
 


### PR DESCRIPTION
1. CF nbits stored per v3 pool. calculation is to take most significant bit of numTicks then +1
2. update CF nodes when unstaking

final step in next PR: use `_cumulativeAccumulatedRewardsX64` to calculate actual rewards